### PR TITLE
#14 - Rename Obsidian jTab to jTab Guitar Codeblocks everywhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-### Obsidian jTab Guide
+### Guide for jTab Guitar Codeblocks
 
-Obsidian jTab adds the ability to show guitar chords and tabs directly in your notes.
+jTab Guitar Codeblocks adds the ability to show guitar chords and tabs directly in your notes.
 
 It uses the [jTab](https://jtab.tardate.com/) library to render the chords/tabs.
 
@@ -15,7 +15,7 @@ It uses the [jTab](https://jtab.tardate.com/) library to render the chords/tabs.
 * ```` ```jtab-chords````  
   Type an empty codeblock to see all available chords (names only). Cut/paste anything off the list into a normal jtab codeblock to see the chord charts.
 
-#### Enhancements specific to Obsidian jTab
+#### Enhancements specific to jTab Guitar Codeblocks
 1. _Supports multiple jTab lines per codeblock_  
    Each jTab line in a codeblock will be individually rendered. Blank lines will be ignored.
 
@@ -94,7 +94,7 @@ __jTab examples codeblock__
 _Community Support_
 * Thanks for @RobColes for suggesting #5 (customizing colors) and being a beta tester.
 
-_Used by Obsidian jTab_
+_Used by jTab Guitar Codeblocks_
 * [jTab](https://jtab.tardate.com/)
   * License LGPL v2.1 (it's in it's [js file](https://github.com/tardate/jtab/blob/master/javascripts/jtab.js), not in a normal GitHub license file
   	Per LGPL rules, jTab is used unmodified *execpt*I do not modify the jTab source code other than to

--- a/assets/js/jtab.tardate.js
+++ b/assets/js/jtab.tardate.js
@@ -1,4 +1,4 @@
-/* - Obsidian jTab Addition - */
+/* - jTab Guitar Codeblocks Addition - */
 import jQuery, { grep } from "jquery";
 import Raphael, { fn } from "raphael";
 import ChordLibrary from "./jtab.chords";
@@ -774,6 +774,6 @@ window.onload = function() {
   jtab.renderimplicit(null);
 }
 
-/* - Obsidian jTab Addition - */
+/* - jTab Guitar Codeblocks Addition - */
 export {jtab, jtabChord}
 /* ^^^^^^^^^^^^^^^^^^^^^^^^^^ */

--- a/docs/jtab-color-settings-sdd.md
+++ b/docs/jtab-color-settings-sdd.md
@@ -1,7 +1,7 @@
 # How I added jTab Color Settings in Obsidian
 >This is a how-to guide on how I implemented a live preview in settings and self-updating codeblocks on the fly
 
-I just released Obsidian jTab 1.0.5 with a new settings panel for custom colors that had some odd requirements that I thought I'd share in case anyone could use the ideas (or give me tips on how to do it better).
+I just released jTab Guitar Codeblocks 1.0.5 with a new settings panel for custom colors that had some odd requirements that I thought I'd share in case anyone could use the ideas (or give me tips on how to do it better).
 
 Note: as time passes and these files change, some of these permalinks might be a bit, but not too far off, from the linked number
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -3,7 +3,7 @@ import process from "process";
 import builtins from 'builtin-modules'
 import {sassPlugin} from 'esbuild-sass-plugin'
 
-const banner  = `/* Obsidian jTab Community plugin: https://github.com/davfive/obsidian-jtab */`;
+const banner  = `/* jTab Guitar Codeblocks for Obsidian community plugin: https://github.com/davfive/obsidian-jtab */`;
 
 const prod = (process.argv[2] === 'production');
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"id": "obsidian-jtab",
-	"name": "jTab",
+	"name": "jTab Guitar Codeblocks",
 	"version": "1.2.2",
 	"minAppVersion": "0.12.0",
 	"description": "Adds the ability to show guitar chords and tabs directly in your notes using jTab.",

--- a/src/jtab-utils.ts
+++ b/src/jtab-utils.ts
@@ -5,7 +5,9 @@ export {jtab} from '../assets/js/jtab.tardate'
 
 // Ideally I would just pull this verbatim from the README.md file but esbuild won't let me
 export const jTabAboutMarkdown = `
-Obsidian jTab adds the ability to show guitar chords and tabs directly in your notes.
+### Guide for jTab Guitar Codeblocks
+
+jTab Guitar Codeblocks adds the ability to show guitar chords and tabs directly in your notes.
 
 It uses the [jTab](https://jtab.tardate.com/) library to render the chords/tabs.
 
@@ -17,7 +19,7 @@ It uses the [jTab](https://jtab.tardate.com/) library to render the chords/tabs.
 * \`\`\`\` \`\`\`jtab-examples\`\`\`\`
   Type an empty codeblock to see all of the [jTab examples](https://jtab.tardate.com/examples.htm)
 
-#### Enhancements specific to Obsidian jTab
+#### Enhancements specific to jTab Guitar Codeblocks
 1. _Supports multiple jTab lines per codeblock_
    Each jTab line in a codeblock will be individually rendered
 
@@ -52,7 +54,7 @@ You can put all of the examples from the jTab website directly into your notes b
 * _What about chordonly and tabonly classes mentioned on the jTab site?_
   The jTab library auto-detects if there are chords and/or tabs when rendereing jTab. On the examples page it mentions using chordonly and tabonly classes. They have no effect on the generated tab. They are only there to adust the height of the surrounding div to match the height of the generaged svg. With modern broswers these classes no longer needed.
 
-#### Obsidian jTab on GitHub
+#### jTab Guitar Codeblocks on GitHub
 This plugin's source code and issue tracker can be found on [GitHub](https://github.com/davfive/obsidian-jtab)
 `
 


### PR DESCRIPTION
### Overview

The Obsidian team has asked that we not use the word "Obsidian" in our plugin names. The "renamed" mine to simply jTab.

### Changes

I am renaming it to "jTab Guitar Codeblocks" and will be submitting a request for the formal name change.

